### PR TITLE
Changes `pill`'s border-radius to 9999px

### DIFF
--- a/data/tokens.json
+++ b/data/tokens.json
@@ -756,7 +756,7 @@
       "type": "borderRadius"
     },
     "pill": {
-      "value": "50%",
+      "value": "9999px",
       "type": "borderRadius"
     },
     "circle": {


### PR DESCRIPTION
#### What does this PR do:

* Changes `pill`'s border-radius to 9999px fixing this issue:
![image](https://user-images.githubusercontent.com/89906313/180993737-cd28b6dc-ca35-45aa-b72d-e8e2e6b92b26.png)
