### PR TITLE
Add missing px string to fontSize tokens

### DIFF
--- a/data/tokens.json
+++ b/data/tokens.json
@@ -116,43 +116,43 @@
     },
     "fontSize": {
       "0": {
-        "value": "10",
+        "value": "10px",
         "type": "fontSizes"
       },
       "1": {
-        "value": "12",
+        "value": "12px",
         "type": "fontSizes"
       },
       "2": {
-        "value": "14",
+        "value": "14px",
         "type": "fontSizes"
       },
       "3": {
-        "value": "16",
+        "value": "16px",
         "type": "fontSizes"
       },
       "4": {
-        "value": "18",
+        "value": "18px",
         "type": "fontSizes"
       },
       "5": {
-        "value": "22",
+        "value": "22px",
         "type": "fontSizes"
       },
       "6": {
-        "value": "26",
+        "value": "26px",
         "type": "fontSizes"
       },
       "7": {
-        "value": "28",
+        "value": "28px",
         "type": "fontSizes"
       },
       "8": {
-        "value": "38",
+        "value": "38px",
         "type": "fontSizes"
       },
       "9": {
-        "value": "48",
+        "value": "48px",
         "type": "fontSizes"
       }
     },


### PR DESCRIPTION
This PR adds px to fontSize tokens to display proper _typography tokens